### PR TITLE
fix: migrate CI/CD Docker builds to cyanprint --build [CU-86ex0j5k7]

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,37 +5,11 @@ on:
     tags:
       - 'v*.*.*'
 jobs:
-  #
-  docker:
-    name: Build Docker Image - ${{ matrix.image_name }}
-    strategy:
-      matrix:
-        include:
-          - context: ./cyan
-            dockerfile: ./cyan/Dockerfile
-            image_name: template-template
-          - context: ./cyan
-            dockerfile: ./cyan/blob.Dockerfile
-            image_name: template-blob
-    uses: ./.github/workflows/⚡reusable-docker.yaml
-    secrets: inherit
-    with:
-      atomi_platform: ketone
-      atomi_service: new-cyanprint
-
-      context: ${{ matrix.context }}
-      dockerfile: ${{ matrix.dockerfile }}
-      image_name: ${{ matrix.image_name }}
-
-      version: ${{ github.ref_name }}
-
   cyanprint:
-    name: Push to Cyanprint
-    needs: docker
+    name: Build and Push
     uses: ./.github/workflows/⚡reusable-cyanprint.yaml
     secrets: inherit
     with:
       atomi_platform: ketone
       atomi_service: new-cyanprint
-
       version: ${{ github.ref_name }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   cyanprint:
     name: Build and Push
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: ./.github/workflows/⚡reusable-cyanprint.yaml
     secrets: inherit
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,10 @@ jobs:
   docker:
     name: Docker Build
     needs: test
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     runs-on:
       - nscloud-ubuntu-22.04-amd64-4x8-with-cache
       - nscloud-cache-size-50gb

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,27 +31,31 @@ jobs:
           export GITHUB_REPO_REF
           nix develop .#ci -c cyanprint --version
           nix develop .#ci -c cyanprint test template .
-  #
   docker:
-    name: Build Docker - ${{ matrix.image_name }}
+    name: Docker Build
     needs: test
-    strategy:
-      matrix:
-        include:
-          - context: ./cyan
-            dockerfile: ./cyan/Dockerfile
-            image_name: template-template
-          - context: ./cyan
-            dockerfile: ./cyan/blob.Dockerfile
-            image_name: template-blob
-    uses: ./.github/workflows/⚡reusable-docker.yaml
-    secrets: inherit
-    with:
-      atomi_platform: ketone
-      atomi_service: new-cyanprint
-
-      context: ${{ matrix.context }}
-      dockerfile: ${{ matrix.dockerfile }}
-      image_name: ${{ matrix.image_name }}
-  #
-  #
+    runs-on:
+      - nscloud-ubuntu-22.04-amd64-4x8-with-cache
+      - nscloud-cache-size-50gb
+      - nscloud-cache-tag-ketone-new-cyanprint-nix-store-cache
+    steps:
+      - uses: actions/checkout@v4
+      - uses: AtomiCloud/actions.setup-nix@v2
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Docker Images
+        env:
+          DOMAIN: ghcr.io
+          GITHUB_REPO_REF: ${{ github.repository }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USER: ${{ github.actor }}
+        run: |
+          GITHUB_REPO_REF="$(echo "${GITHUB_REPO_REF}" | tr '[:upper:]' '[:lower:]')"
+          export GITHUB_REPO_REF
+          IMAGE_VERSION="${GITHUB_SHA:0:6}-$(echo "${GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9._-]//g' | sed 's/[._-]*$//')"
+          nix develop .#ci -c cyanprint build "${IMAGE_VERSION}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,8 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: AtomiCloud/actions.setup-nix@v2
-      - uses: docker/setup-buildx-action@v3
+      - uses: rlespinasse/github-slug-action@v3.x
       - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -57,5 +58,6 @@ jobs:
         run: |
           GITHUB_REPO_REF="$(echo "${GITHUB_REPO_REF}" | tr '[:upper:]' '[:lower:]')"
           export GITHUB_REPO_REF
-          IMAGE_VERSION="${GITHUB_SHA:0:6}-$(echo "${GITHUB_REF_NAME}" | sed 's/[^a-zA-Z0-9._-]//g' | sed 's/[._-]*$//')"
+          BRANCH="${GITHUB_REF_SLUG//[._-]*$//}"
+          IMAGE_VERSION="${GITHUB_SHA:0:6}-${BRANCH}"
           nix develop .#ci -c cyanprint build "${IMAGE_VERSION}"

--- a/.github/workflows/⚡reusable-cyanprint.yaml
+++ b/.github/workflows/⚡reusable-cyanprint.yaml
@@ -25,8 +25,8 @@ jobs:
       - uses: AtomiCloud/actions.setup-nix@v2
       - uses: actions/checkout@v4
       # Docker setup
-      - uses: docker/setup-buildx-action@v3
       - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io

--- a/.github/workflows/⚡reusable-cyanprint.yaml
+++ b/.github/workflows/⚡reusable-cyanprint.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   cyanprint:
-    name: Push to Cyanprint
+    name: Build and Push
     runs-on:
       - nscloud-ubuntu-22.04-amd64-4x8-with-cache
       - nscloud-cache-size-50gb
@@ -23,10 +23,22 @@ jobs:
     steps:
       # Setup
       - uses: AtomiCloud/actions.setup-nix@v2
-      # Push to Cyanprint
-      - name: Pushh to cyanprint
+      - uses: actions/checkout@v4
+      # Docker setup
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Build and Push
+      - name: Build and Push to Cyanprint
         env:
           DOMAIN: ghcr.io
           GITHUB_REPO_REF: ${{ github.repository }}
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USER: ${{ github.actor }}
           CYAN_TOKEN: ${{ secrets.CYAN_TOKEN }}
-        run: nix develop .#ci -c ./scripts/publish.sh ${{ inputs.version }}
+          IMAGE_VERSION: ${{ inputs.version }}
+        run: nix develop .#ci -c ./scripts/publish.sh

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 set -eou pipefail
+[ "${DOMAIN:-}" = '' ] && echo "DOMAIN not set" && exit 1
+[ "${GITHUB_REPO_REF:-}" = '' ] && echo "GITHUB_REPO_REF not set" && exit 1
+[ "${DOCKER_PASSWORD:-}" = '' ] && echo "DOCKER_PASSWORD not set" && exit 1
+[ "${DOCKER_USER:-}" = '' ] && echo "DOCKER_USER not set" && exit 1
 [ "${CYAN_TOKEN:-}" = '' ] && echo "CYAN_TOKEN not set" && exit 1
 [ "${IMAGE_VERSION:-}" = '' ] && echo "IMAGE_VERSION not set" && exit 1
+GITHUB_REPO_REF="$(echo "${GITHUB_REPO_REF}" | tr '[:upper:]' '[:lower:]')"
+export GITHUB_REPO_REF
 cyanprint push --token "${CYAN_TOKEN}" template --build "${IMAGE_VERSION}"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,32 +1,5 @@
 #!/usr/bin/env bash
-
-# check for necessary env vars
-[ "${DOMAIN}" = '' ] && echo "❌ 'DOMAIN' env var not set" && exit 1
-[ "${GITHUB_REPO_REF}" = '' ] && echo "❌ 'GITHUB_REPO_REF' env var not set" && exit 1
-
-[ "${CYAN_TOKEN}" = '' ] && echo "❌ 'CYAN_TOKEN' env var not set" && exit 1
-
-IMAGE_VERSION="$1"
-
-[ "${IMAGE_VERSION}" = '' ] && echo "❌ 'IMAGE_VERSION' argument missing" && exit 1
-
 set -eou pipefail
-
-# Obtain image
-BLOB_IMAGE_ID="${DOMAIN}/${GITHUB_REPO_REF}/template-blob"
-BLOB_IMAGE_ID=$(echo "${BLOB_IMAGE_ID}" | tr '[:upper:]' '[:lower:]') # convert to lower case
-# Generate image references
-BLOB_COMMIT_IMAGE_REF="${BLOB_IMAGE_ID}:${IMAGE_VERSION}"
-
-TEMPLATE_IMAGE_ID="${DOMAIN}/${GITHUB_REPO_REF}/template-template"
-TEMPLATE_IMAGE_ID=$(echo "${TEMPLATE_IMAGE_ID}" | tr '[:upper:]' '[:lower:]') # convert to lower case
-# Generate image references
-TEMPLATE_COMMIT_IMAGE_REF="${TEMPLATE_IMAGE_ID}:${IMAGE_VERSION}"
-
-# Generate cache references
-echo "  ✅ Blob Commit Image Ref: ${BLOB_COMMIT_IMAGE_REF}"
-echo "  ✅ Template Commit Image Ref: ${TEMPLATE_COMMIT_IMAGE_REF}"
-
-echo "🔨 Pushing to Cyanprint..."
-cyanprint push template "${BLOB_IMAGE_ID}" "${IMAGE_VERSION}" "${TEMPLATE_IMAGE_ID}" "${IMAGE_VERSION}"
-echo "✅ Pushed to Cyanprint!"
+[ "${CYAN_TOKEN:-}" = '' ] && echo "CYAN_TOKEN not set" && exit 1
+[ "${IMAGE_VERSION:-}" = '' ] && echo "IMAGE_VERSION not set" && exit 1
+cyanprint push --token "${CYAN_TOKEN}" template --build "${IMAGE_VERSION}"

--- a/spec/CU-86ex0j5k7/v1/plans/plan-1.md
+++ b/spec/CU-86ex0j5k7/v1/plans/plan-1.md
@@ -18,8 +18,8 @@ The workflow triggers on tag push (`v*.*.*`) and passes the version to `cyanprin
 
 Add Docker setup steps before the cyanprint push step:
 
-- `docker/setup-buildx-action@v3`
 - `docker/setup-qemu-action@v3`
+- `docker/setup-buildx-action@v3`
 - `docker/login-action@v3` with `ghcr.io`
 
 Pass `DOCKER_PASSWORD` and `DOCKER_USER` as env vars so `cyanprint push --build` can authenticate with the registry.

--- a/spec/CU-86ex0j5k7/v1/plans/plan-1.md
+++ b/spec/CU-86ex0j5k7/v1/plans/plan-1.md
@@ -1,0 +1,39 @@
+# Plan 1: Migrate CD pipeline to `cyanprint push --build`
+
+## Files Modified
+
+- `.github/workflows/cd.yaml` — rewrite: remove matrix docker job, replace cyanprint job with unified build+push
+- `.github/workflows/⚡reusable-cyanprint.yaml` — update: add Docker setup steps, change publish script to use `--build`
+- `scripts/publish.sh` — simplify: use `cyanprint push --build` instead of manual image refs
+
+## Changes
+
+### `.github/workflows/cd.yaml`
+
+Remove the `docker` matrix job entirely. The `cyanprint` job now handles everything: Docker setup (buildx, qemu, registry login) + building images + pushing to registry + registering with CyanPrint.
+
+The workflow triggers on tag push (`v*.*.*`) and passes the version to `cyanprint push --build`.
+
+### `.github/workflows/⚡reusable-cyanprint.yaml`
+
+Add Docker setup steps before the cyanprint push step:
+
+- `docker/setup-buildx-action@v3`
+- `docker/setup-qemu-action@v3`
+- `docker/login-action@v3` with `ghcr.io`
+
+Pass `DOCKER_PASSWORD` and `DOCKER_USER` as env vars so `cyanprint push --build` can authenticate with the registry.
+
+### `scripts/publish.sh`
+
+Replace the manual image ref construction and old `cyanprint push template <blob> <ver> <template> <ver>` syntax with:
+
+```bash
+#!/usr/bin/env bash
+set -eou pipefail
+[ "${CYAN_TOKEN:-}" = '' ] && echo "CYAN_TOKEN not set" && exit 1
+[ "${IMAGE_VERSION:-}" = '' ] && echo "IMAGE_VERSION not set" && exit 1
+cyanprint push --token "${CYAN_TOKEN}" template --build "${IMAGE_VERSION}"
+```
+
+This matches the pattern already used by templates generated from this meta-template.

--- a/spec/CU-86ex0j5k7/v1/plans/plan-2.md
+++ b/spec/CU-86ex0j5k7/v1/plans/plan-2.md
@@ -1,0 +1,24 @@
+# Plan 2: Migrate CI Docker build to `cyanprint build`
+
+## Files Modified
+
+- `.github/workflows/ci.yaml` — replace matrix docker job with `cyanprint build`
+
+## Changes
+
+### `.github/workflows/ci.yaml`
+
+Remove the matrix-based `docker` job (lines 34-55). Replace with a new job that:
+
+1. Runs on `ubuntu-22.04` (or nscloud runner if Docker is available there)
+2. Sets up Docker (buildx, qemu, login) via GitHub Actions
+3. Installs cyanprint via nix develop
+4. Runs `cyanprint build <version>` to validate all images build correctly without pushing
+
+The `needs: test` dependency is preserved — Docker builds only run after tests pass.
+
+## Notes
+
+- `cyanprint build` reads the `build` section from `cyan.yaml`, so no image configuration is needed in the workflow
+- The version for CI is a commit SHA + branch slug (same pattern as current `docker.sh`)
+- Registry login is still needed because `cyanprint build` pushes to the registry as part of the build process (buildx multi-platform requires push)

--- a/spec/CU-86ex0j5k7/v1/task-spec.md
+++ b/spec/CU-86ex0j5k7/v1/task-spec.md
@@ -13,7 +13,7 @@ The CD pipeline (`cd.yaml`) and CI pipeline (`ci.yaml`) use a matrix-based appro
 Replace the matrix-based Docker build approach with `cyanprint`'s native `--build` flag, which reads the `build` section from `cyan.yaml` directly. This makes `cyan.yaml` the single source of truth for image build configuration.
 
 - **CD**: Use `cyanprint push --build <version>` — builds all images and pushes to registry + CyanPrint in one command
-- **CI**: Use `cyanprint build <version>` — builds all images without pushing (validation only)
+- **CI**: Use `cyanprint build <version>` — builds all images using Docker buildx (multi-platform builds push to registry, so GHCR login is required)
 
 ## Acceptance Criteria
 

--- a/spec/CU-86ex0j5k7/v1/task-spec.md
+++ b/spec/CU-86ex0j5k7/v1/task-spec.md
@@ -1,0 +1,60 @@
+# Task Spec: Migrate CD/CI Docker builds to `cyanprint push --build` / `cyanprint build`
+
+## Ticket
+
+CU-86ex0j5k7 — Fix blob image build context in ketone/new-cyanprint CD pipeline
+
+## Problem
+
+The CD pipeline (`cd.yaml`) and CI pipeline (`ci.yaml`) use a matrix-based approach to build Docker images via `scripts/ci/docker.sh`. The matrix hardcodes `context`, `dockerfile`, and `image_name` for each image, duplicating what `cyan.yaml` already declares. This caused a drift: `cyan.yaml` correctly specifies `context: .` for the blob image, but the matrix had `context: ./cyan`, producing broken blob images.
+
+## Solution
+
+Replace the matrix-based Docker build approach with `cyanprint`'s native `--build` flag, which reads the `build` section from `cyan.yaml` directly. This makes `cyan.yaml` the single source of truth for image build configuration.
+
+- **CD**: Use `cyanprint push --build <version>` — builds all images and pushes to registry + CyanPrint in one command
+- **CI**: Use `cyanprint build <version>` — builds all images without pushing (validation only)
+
+## Acceptance Criteria
+
+### CD Pipeline (`cd.yaml`)
+
+1. Remove the matrix-based `docker` job entirely
+2. Replace with a single job that uses `nix develop .#ci -c cyanprint push --build <version>`
+3. The `⚡reusable-cyanprint.yaml` workflow handles the cyanprint push step
+4. `scripts/publish.sh` (root) is updated to use `cyanprint push --build` instead of the old manual `cyanprint push template <blob> <ver> <template> <ver>` syntax
+5. `scripts/ci/docker.sh` is no longer called from CD
+6. Docker setup (buildx, qemu, login) is handled as workflow steps before the cyanprint command
+
+### CI Pipeline (`ci.yaml`)
+
+1. Remove the matrix-based `docker` job
+2. Replace with a job that runs `cyanprint build <version>` to validate all Docker images build correctly
+3. Docker setup (buildx, qemu, login) is handled as workflow steps before the cyanprint command
+
+### Cleanup
+
+1. `scripts/ci/docker.sh` can remain (it may be used by the template pattern for other repos), but is no longer used by this repo's CI/CD
+2. `scripts/publish.sh` (root) is simplified to use the new `cyanprint push --build` command
+
+### Constraints
+
+- `cyan.yaml` already has the correct build configuration — no changes needed to `cyan.yaml`
+- The template's cyan.yaml (`template/cyan.yaml`) already generates correct build configs for new projects — no changes needed there
+- Must work within the existing Nix shell environment (`nix develop .#ci` provides cyanprint)
+- Must maintain the existing tagging strategy: semver tags on CD, commit+branch on CI
+- Must maintain registry login via `ghcr.io` with `${{ secrets.GITHUB_TOKEN }}`
+
+### Out of Scope
+
+- Updating snapshot test expected outputs (if cyan.yaml output changes)
+- Modifying the `⚡reusable-docker.yaml` workflow (it remains for use by other repos following the old pattern)
+- Modifying the `⚡reusable-cyanprint.yaml` workflow structure
+- Updating the `template/common/.github/workflows/publish.yaml` or `template/common/scripts/publish.sh` (those already use the new method)
+
+## Context
+
+- The meta-template's own `cyan.yaml` already declares the correct build config: `blob.context: .`, `template.context: ./cyan`
+- Templates generated from this meta-template already use `cyanprint push --build` in their publish.sh
+- `cyanprint build` reads `cyan.yaml` build section and uses Docker buildx for multi-platform builds
+- `cyanprint push --build` combines building + pushing images + registering with CyanPrint

--- a/spec/CU-86ex0j5k7/v1/task-spec.md
+++ b/spec/CU-86ex0j5k7/v1/task-spec.md
@@ -49,7 +49,6 @@ Replace the matrix-based Docker build approach with `cyanprint`'s native `--buil
 
 - Updating snapshot test expected outputs (if cyan.yaml output changes)
 - Modifying the `⚡reusable-docker.yaml` workflow (it remains for use by other repos following the old pattern)
-- Modifying the `⚡reusable-cyanprint.yaml` workflow structure
 - Updating the `template/common/.github/workflows/publish.yaml` or `template/common/scripts/publish.sh` (those already use the new method)
 
 ## Context


### PR DESCRIPTION
## Summary

- Replace matrix-based Docker image builds with `cyanprint` native `--build` commands that read `cyan.yaml` as the single source of truth
- CD: `cyanprint push --build` handles build + push + registry registration in one step
- CI: `cyanprint build` validates all images build correctly
- Simplify `scripts/publish.sh` to use new syntax (matches what generated templates already use)
- Add Docker setup steps (buildx, qemu, login) to `⚡reusable-cyanprint.yaml`

## Context

The old matrix approach hardcoded `context`, `dockerfile`, and `image_name` in the workflow, duplicating `cyan.yaml`. This caused a drift where the blob image was built with `context: ./cyan` instead of the correct `context: .`, producing broken blob images missing `template/`, `processor/`, and `plugin/` directories.

Closes: CU-86ex0j5k7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated image build/publish into single CI/CD jobs, removing the previous matrix-based Docker job.
  * Renamed publish step to “Build and Push”, moved Docker/QEMU/Buildx setup and registry login into workflow steps, added explicit job permissions, and switched to environment-driven build/push invocation.

* **Documentation**
  * Added migration plans and a task spec documenting the new CI/CD build/push flow, versioning, and runtime checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->