### PR TITLE
[CU-86ex0z8ug] Add .cyan_output/ and .cyan_backup*/ to .gitignore in new-cyanprint template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ spec/
 .kagent/
 .claude/
 .cyan_output/
+.cyan_backup*/
 .cyan_state.yaml
 test.cyan.yaml
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .direnv
 .pre-commit-config.yaml
 .kagent/
+
+.cyan_output/
+.cyan_backup*/

--- a/plugin/common/.dockerignore
+++ b/plugin/common/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/plugin/common/.gitignore
+++ b/plugin/common/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/plugin/dotnet/.dockerignore
+++ b/plugin/dotnet/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/plugin/dotnet/.gitignore
+++ b/plugin/dotnet/.gitignore
@@ -1,3 +1,5 @@
 bin
 obj
 .idea
+.cyan_output/
+.cyan_backup*/

--- a/plugin/javascript/.dockerignore
+++ b/plugin/javascript/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/plugin/javascript/.gitignore
+++ b/plugin/javascript/.gitignore
@@ -174,3 +174,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/plugin/python/.dockerignore
+++ b/plugin/python/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/plugin/python/.gitignore
+++ b/plugin/python/.gitignore
@@ -1,3 +1,5 @@
 env
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/plugin/typescript/.dockerignore
+++ b/plugin/typescript/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/plugin/typescript/.gitignore
+++ b/plugin/typescript/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/processor/common/.dockerignore
+++ b/processor/common/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/processor/common/.gitignore
+++ b/processor/common/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/processor/dotnet/.dockerignore
+++ b/processor/dotnet/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/processor/dotnet/.gitignore
+++ b/processor/dotnet/.gitignore
@@ -1,3 +1,5 @@
 bin
 obj
 .idea
+.cyan_output/
+.cyan_backup*/

--- a/processor/javascript/.dockerignore
+++ b/processor/javascript/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/processor/javascript/.gitignore
+++ b/processor/javascript/.gitignore
@@ -174,3 +174,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/processor/python/.dockerignore
+++ b/processor/python/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/processor/python/.gitignore
+++ b/processor/python/.gitignore
@@ -1,3 +1,5 @@
 env
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/processor/typescript/.dockerignore
+++ b/processor/typescript/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/processor/typescript/.gitignore
+++ b/processor/typescript/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/common/.dockerignore
+++ b/resolver/common/.dockerignore
@@ -20,3 +20,6 @@ README.MD
 **/obj/
 **/node_modules/
 **/env.
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/common/.gitignore
+++ b/resolver/common/.gitignore
@@ -3,3 +3,6 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/dotnet/.dockerignore
+++ b/resolver/dotnet/.dockerignore
@@ -23,3 +23,6 @@
 **/values.dev.yaml
 LICENSE
 README.md
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/dotnet/.gitignore
+++ b/resolver/dotnet/.gitignore
@@ -1,3 +1,6 @@
 bin
 obj
 .idea
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/javascript/.dockerignore
+++ b/resolver/javascript/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/javascript/.gitignore
+++ b/resolver/javascript/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/python/.dockerignore
+++ b/resolver/python/.dockerignore
@@ -2,3 +2,6 @@ env
 venv
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/python/.gitignore
+++ b/resolver/python/.gitignore
@@ -1,3 +1,6 @@
 env
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/typescript/.dockerignore
+++ b/resolver/typescript/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/resolver/typescript/.gitignore
+++ b/resolver/typescript/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_dotnet_no_skills/.dockerignore
+++ b/snapshots/plugin_dotnet_no_skills/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_dotnet_no_skills/.gitignore
+++ b/snapshots/plugin_dotnet_no_skills/.gitignore
@@ -1,3 +1,5 @@
 bin
 obj
 .idea
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_dotnet_with_skills/.dockerignore
+++ b/snapshots/plugin_dotnet_with_skills/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_dotnet_with_skills/.gitignore
+++ b/snapshots/plugin_dotnet_with_skills/.gitignore
@@ -1,3 +1,5 @@
 bin
 obj
 .idea
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_javascript_no_skills/.dockerignore
+++ b/snapshots/plugin_javascript_no_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_javascript_no_skills/.gitignore
+++ b/snapshots/plugin_javascript_no_skills/.gitignore
@@ -174,3 +174,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_javascript_with_skills/.dockerignore
+++ b/snapshots/plugin_javascript_with_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_javascript_with_skills/.gitignore
+++ b/snapshots/plugin_javascript_with_skills/.gitignore
@@ -174,3 +174,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_python_no_skills/.dockerignore
+++ b/snapshots/plugin_python_no_skills/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_python_no_skills/.gitignore
+++ b/snapshots/plugin_python_no_skills/.gitignore
@@ -1,3 +1,5 @@
 env
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_python_with_skills/.dockerignore
+++ b/snapshots/plugin_python_with_skills/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_python_with_skills/.gitignore
+++ b/snapshots/plugin_python_with_skills/.gitignore
@@ -1,3 +1,5 @@
 env
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_typescript_no_skills/.dockerignore
+++ b/snapshots/plugin_typescript_no_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_typescript_no_skills/.gitignore
+++ b/snapshots/plugin_typescript_no_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_typescript_with_skills/.dockerignore
+++ b/snapshots/plugin_typescript_with_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/plugin_typescript_with_skills/.gitignore
+++ b/snapshots/plugin_typescript_with_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_dotnet_no_skills/.dockerignore
+++ b/snapshots/processor_dotnet_no_skills/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_dotnet_no_skills/.gitignore
+++ b/snapshots/processor_dotnet_no_skills/.gitignore
@@ -1,3 +1,5 @@
 bin
 obj
 .idea
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_dotnet_with_skills/.dockerignore
+++ b/snapshots/processor_dotnet_with_skills/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_dotnet_with_skills/.gitignore
+++ b/snapshots/processor_dotnet_with_skills/.gitignore
@@ -1,3 +1,5 @@
 bin
 obj
 .idea
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_javascript_no_skills/.dockerignore
+++ b/snapshots/processor_javascript_no_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_javascript_no_skills/.gitignore
+++ b/snapshots/processor_javascript_no_skills/.gitignore
@@ -174,3 +174,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_javascript_with_skills/.dockerignore
+++ b/snapshots/processor_javascript_with_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_javascript_with_skills/.gitignore
+++ b/snapshots/processor_javascript_with_skills/.gitignore
@@ -174,3 +174,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_python_no_skills/.dockerignore
+++ b/snapshots/processor_python_no_skills/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_python_no_skills/.gitignore
+++ b/snapshots/processor_python_no_skills/.gitignore
@@ -1,3 +1,5 @@
 env
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_python_with_skills/.dockerignore
+++ b/snapshots/processor_python_with_skills/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_python_with_skills/.gitignore
+++ b/snapshots/processor_python_with_skills/.gitignore
@@ -1,3 +1,5 @@
 env
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_typescript_no_skills/.dockerignore
+++ b/snapshots/processor_typescript_no_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_typescript_no_skills/.gitignore
+++ b/snapshots/processor_typescript_no_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_typescript_with_skills/.dockerignore
+++ b/snapshots/processor_typescript_with_skills/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/processor_typescript_with_skills/.gitignore
+++ b/snapshots/processor_typescript_with_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_dotnet_no_skills/.dockerignore
+++ b/snapshots/resolver_dotnet_no_skills/.dockerignore
@@ -23,3 +23,6 @@
 **/values.dev.yaml
 LICENSE
 README.md
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_dotnet_no_skills/.gitignore
+++ b/snapshots/resolver_dotnet_no_skills/.gitignore
@@ -1,3 +1,6 @@
 bin
 obj
 .idea
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_dotnet_with_skills/.dockerignore
+++ b/snapshots/resolver_dotnet_with_skills/.dockerignore
@@ -23,3 +23,6 @@
 **/values.dev.yaml
 LICENSE
 README.md
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_dotnet_with_skills/.gitignore
+++ b/snapshots/resolver_dotnet_with_skills/.gitignore
@@ -1,3 +1,6 @@
 bin
 obj
 .idea
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_javascript_no_skills/.dockerignore
+++ b/snapshots/resolver_javascript_no_skills/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_javascript_no_skills/.gitignore
+++ b/snapshots/resolver_javascript_no_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_javascript_with_skills/.dockerignore
+++ b/snapshots/resolver_javascript_with_skills/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_javascript_with_skills/.gitignore
+++ b/snapshots/resolver_javascript_with_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_python_no_skills/.dockerignore
+++ b/snapshots/resolver_python_no_skills/.dockerignore
@@ -2,3 +2,6 @@ env
 venv
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_python_no_skills/.gitignore
+++ b/snapshots/resolver_python_no_skills/.gitignore
@@ -1,3 +1,6 @@
 env
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_python_with_skills/.dockerignore
+++ b/snapshots/resolver_python_with_skills/.dockerignore
@@ -2,3 +2,6 @@ env
 venv
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_python_with_skills/.gitignore
+++ b/snapshots/resolver_python_with_skills/.gitignore
@@ -1,3 +1,6 @@
 env
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_typescript_no_skills/.dockerignore
+++ b/snapshots/resolver_typescript_no_skills/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_typescript_no_skills/.gitignore
+++ b/snapshots/resolver_typescript_no_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_typescript_with_skills/.dockerignore
+++ b/snapshots/resolver_typescript_with_skills/.dockerignore
@@ -1,3 +1,6 @@
 node_modules
 .idea
 .vscode
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/resolver_typescript_with_skills/.gitignore
+++ b/snapshots/resolver_typescript_with_skills/.gitignore
@@ -175,3 +175,6 @@ dist
 ### Finder (MacOS) folder config
 .DS_Store
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_dotnet_no_skills/.dockerignore
+++ b/snapshots/template_dotnet_no_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_dotnet_no_skills/.gitignore
+++ b/snapshots/template_dotnet_no_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_dotnet_no_skills/cyan/.dockerignore
+++ b/snapshots/template_dotnet_no_skills/cyan/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_dotnet_with_skills/.dockerignore
+++ b/snapshots/template_dotnet_with_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_dotnet_with_skills/.gitignore
+++ b/snapshots/template_dotnet_with_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_dotnet_with_skills/cyan/.dockerignore
+++ b/snapshots/template_dotnet_with_skills/cyan/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_javascript_no_skills/.dockerignore
+++ b/snapshots/template_javascript_no_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_javascript_no_skills/.gitignore
+++ b/snapshots/template_javascript_no_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_javascript_no_skills/cyan/.dockerignore
+++ b/snapshots/template_javascript_no_skills/cyan/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_javascript_with_skills/.dockerignore
+++ b/snapshots/template_javascript_with_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_javascript_with_skills/.gitignore
+++ b/snapshots/template_javascript_with_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_javascript_with_skills/cyan/.dockerignore
+++ b/snapshots/template_javascript_with_skills/cyan/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_python_no_skills/.dockerignore
+++ b/snapshots/template_python_no_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_python_no_skills/.gitignore
+++ b/snapshots/template_python_no_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_python_no_skills/cyan/.dockerignore
+++ b/snapshots/template_python_no_skills/cyan/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_python_with_skills/.dockerignore
+++ b/snapshots/template_python_with_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_python_with_skills/.gitignore
+++ b/snapshots/template_python_with_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_python_with_skills/cyan/.dockerignore
+++ b/snapshots/template_python_with_skills/cyan/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_typescript_no_skills/.dockerignore
+++ b/snapshots/template_typescript_no_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_typescript_no_skills/.gitignore
+++ b/snapshots/template_typescript_no_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_typescript_no_skills/cyan/.dockerignore
+++ b/snapshots/template_typescript_no_skills/cyan/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_typescript_with_skills/.dockerignore
+++ b/snapshots/template_typescript_with_skills/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_typescript_with_skills/.gitignore
+++ b/snapshots/template_typescript_with_skills/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/snapshots/template_typescript_with_skills/cyan/.dockerignore
+++ b/snapshots/template_typescript_with_skills/cyan/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/template/common/.dockerignore
+++ b/template/common/.dockerignore
@@ -21,3 +21,6 @@ README.MD
 **/node_modules/
 **/env.
 
+
+.cyan_output/
+.cyan_backup*/

--- a/template/common/.gitignore
+++ b/template/common/.gitignore
@@ -3,3 +3,5 @@
 .idea
 .direnv
 .pre-commit-config.yaml
+.cyan_output/
+.cyan_backup*/

--- a/template/dotnet/cyan/.dockerignore
+++ b/template/dotnet/cyan/.dockerignore
@@ -23,3 +23,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+.cyan_output/
+.cyan_backup*/

--- a/template/javascript/cyan/.dockerignore
+++ b/template/javascript/cyan/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/template/python/cyan/.dockerignore
+++ b/template/python/cyan/.dockerignore
@@ -2,3 +2,5 @@ env
 venv
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/

--- a/template/typescript/cyan/.dockerignore
+++ b/template/typescript/cyan/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 .idea
 .vscode
+.cyan_output/
+.cyan_backup*/


### PR DESCRIPTION
## Summary
- Add `.cyan_output/` and `.cyan_backup*/` to all `.gitignore` `common/` files (root covers subdirs recursively) and all `.dockerignore` files (no recursive inheritance) across template, plugin, processor, and resolver template sources
- Update all 34 snapshot root-level `.gitignore` files and 54 snapshot `.dockerignore` files to match

## Context
Closes CU-86ex0z8ug

These entries ensure CyanPrint build artifacts (`.cyan_output/`) and backup directories (`.cyan_backup*/`) are not committed to repos generated from this meta-template.

## Test plan
- [ ] Verify all `common/.gitignore` template sources contain both entries
- [ ] Verify all `.dockerignore` template sources contain both entries
- [ ] Verify all snapshot files match their template sources
- [ ] Verify no nested `cyan/.gitignore` files were modified (parent covers them)
- [ ] Run `cyanprint create` to generate a project and confirm gitignore entries are present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project-wide ignore rules to exclude generated output and backup artifacts (e.g., .cyan_output and .cyan_backup* patterns) from version control and Docker build contexts; normalized trailing newlines in several ignore files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->